### PR TITLE
Set initial date if not set to avoid overriding it

### DIFF
--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -28,7 +28,7 @@ export const useStore = defineStore({
     filters: {},
     weaponRequirements: { ...weaponRequirements },
     masteryRequirements: { ...masteryRequirements },
-    stormenderRequirements: {...stormenderRequirements},
+    stormenderRequirements: { ...stormenderRequirements },
     weapons: [],
     callingCards: {},
     preferences: { ...defaultPreferences },
@@ -146,13 +146,15 @@ export const useStore = defineStore({
     },
 
     storeProgress() {
+      if (this.beganGrind === null) this.beganGrind = new Date()
+
       localStorage.setItem(
         token,
         JSON.stringify({
           weapons: this.weapons,
           callingCards: this.callingCards,
           filters: this.filters,
-          beganGrind: this.beganGrind || new Date(),
+          beganGrind: this.beganGrind,
           favorites: this.favorites,
           preferences: this.preferences,
         })


### PR DESCRIPTION
This would fix #56, which only happens the first time the user uses the page - each time a camo is completed, the `this.beganGrind` variable will not be set and it will get overwritten until the page is closed so next time it is correctly loaded and set when getting it from localstorage