### PR TITLE
Fix camo requirement, camo category name display

### DIFF
--- a/src/data/requirements/weapons/lightMachineGuns.js
+++ b/src/data/requirements/weapons/lightMachineGuns.js
@@ -250,12 +250,12 @@ export default {
     },
 
     'Forged': {
-      times: 10,
+      amount: 10,
       type: 'mounted_headshots',
     },
 
     'Priceless': {
-      times: 10,
+      amount: 10,
       type: 'double_kills_with_full_attachments',
     },
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -613,6 +613,7 @@
     "Blur": "Blur",
     "Bold": "Bold",
     "Butterfly": "Butterfly",
+    "Cute Critters": "Cute Critters",
     "Digital": "Digital",
     "Fun": "Fun",
     "Geometric": "Geometric",


### PR DESCRIPTION
Title was showing incorrectly
<img width="513" alt="image" src="https://github.com/carlssonemil/interstellar/assets/5074186/6869be92-f23f-4b3a-b554-79453eaa4ff0">
