### PR TITLE
Fix missing existing camos

### DIFF
--- a/src/data/camouflages/butterfly.js
+++ b/src/data/camouflages/butterfly.js
@@ -1,4 +1,5 @@
 const multiplayer = [
+  'Imago',
   'Fritillary',
   'Menelaus Blue',
   'Monarch',
@@ -7,7 +8,7 @@ const multiplayer = [
   'Red Admiral',
 ]
 
-const zombies = ['Chaos', 'Death Form', 'Decrepit', 'Grief Manifest', 'Petrified', 'Toxic Spots']
+const zombies = ['Chaos', 'Death Form', 'Decrepit', 'Grief Manifest', 'Petrified', 'Putrid Locust', 'Toxic Spots']
 
 const camouflages = [...multiplayer, ...zombies].sort((a, b) => a.localeCompare(b))
 

--- a/src/data/camouflages/glitchMilspec.js
+++ b/src/data/camouflages/glitchMilspec.js
@@ -6,6 +6,7 @@ const multiplayer = [
   'Oil Slick Glitch',
   'Phantom Glitch',
   'Rainfall Glitch',
+  'Scoured',
   'Twilight Glitch',
 ]
 
@@ -15,6 +16,7 @@ const zombies = [
   'Murk Glitch',
   'Pain Glitch',
   'Slash Glitch',
+  'Sonic Glitch',
   'Spirit Glitch',
   'Tomb Glitch',
   'Torment Glitch',

--- a/src/data/camouflages/glitteryFlats.js
+++ b/src/data/camouflages/glitteryFlats.js
@@ -1,16 +1,17 @@
 const multiplayer = [
   'Amaranth Sands',
   'Blue Sands',
+  'Brown Sands',
   'Cobalt Sands',
+  'Drowned Sands',
   'Green Sands',
+  'Lavender Sands',
   'Orange Sands',
   'Pink Sands',
   'Purple Sands',
   'Red Sands',
   'Sea Green Sands',
   'Yellow Sands',
-  'Brown Sands',
-  'Lavender Sands',
 ]
 
 const zombies = [

--- a/src/data/camouflages/psychedelics.js
+++ b/src/data/camouflages/psychedelics.js
@@ -1,6 +1,6 @@
-const multiplayer = ['Psychedelic Loops','Psychedelic Pop', 'Psychedelic Sky']
+const multiplayer = ['Occult', 'Psychedelic Loops', 'Psychedelic Pop', 'Psychedelic Sky']
 
-const zombies = ['Psychedelic Misery', 'Psychedelic Ridge', 'Psychedelic Toxins']
+const zombies = ['Mystic Wither', 'Psychedelic Misery', 'Psychedelic Ridge', 'Psychedelic Toxins']
 
 const camouflages = [...multiplayer, ...zombies].sort((a, b) => a.localeCompare(b))
 

--- a/src/data/camouflages/topographic.js
+++ b/src/data/camouflages/topographic.js
@@ -19,6 +19,7 @@ const zombies = [
   'Topo Gloom',
   'Topo Grave',
   'Topo Ooze',
+  'Topo Sickly',
   'Topo Spirit',
   'Topo Stone',
 ]

--- a/src/data/camouflages/uncategorized.js
+++ b/src/data/camouflages/uncategorized.js
@@ -1,6 +1,6 @@
 const multiplayer = []
 
-const zombies = ['Unseen Ravager', 'Anomaly']
+const zombies = ['Anomaly']
 
 const camouflages = [...multiplayer, ...zombies].sort((a, b) => a.localeCompare(b))
 

--- a/src/data/camouflages/underTheMicroscope.js
+++ b/src/data/camouflages/underTheMicroscope.js
@@ -1,5 +1,6 @@
 const multiplayer = [
   'Bacterial Decay',
+  'Cold Snap',
   'Deadly Spores',
   'Germ Factory',
   'Microbiology',

--- a/src/data/camouflages/wavelength.js
+++ b/src/data/camouflages/wavelength.js
@@ -1,6 +1,7 @@
 const multiplayer = [
   '80s Spheres',
   'Geofunk',
+  'Gradient Globs',
   'Heatwave',
   'Mind Peak',
   'Psychotropic',
@@ -9,7 +10,9 @@ const multiplayer = [
 
 const zombies = [
   'Alert',
+  'Biomass',
   'Cacophony',
+  'Empty Screams',
   'Global Panic',
   'Lost Transmission',
   'Purple Ooze',

--- a/src/data/camouflages/woodland.js
+++ b/src/data/camouflages/woodland.js
@@ -1,6 +1,6 @@
 const multiplayer = ['Nightshade']
 
-const zombies = []
+const zombies = ['Unseen Ravager']
 
 const camouflages = [...multiplayer, ...zombies].sort((a, b) => a.localeCompare(b))
 

--- a/src/data/requirements/camouflages/uncategorized.js
+++ b/src/data/requirements/camouflages/uncategorized.js
@@ -1,13 +1,4 @@
 export default {
-  'Unseen Ravager': {
-    weapon: 'FR 5.56',
-    level: '13',
-    challenge: {
-      amount: 30,
-      type: 'hellhound_kills',
-    },
-  },
-
   'Anomaly': {
     weapon: 'FR 5.56',
     level: '19',

--- a/src/data/requirements/camouflages/woodland.js
+++ b/src/data/requirements/camouflages/woodland.js
@@ -1,4 +1,12 @@
 export default {
+  'Unseen Ravager': {
+    weapon: 'FR 5.56',
+    level: '13',
+    challenge: {
+      amount: 30,
+      type: 'hellhound_kills',
+    },
+  },
   Nightshade: {
     weapon: 'FR 5.56',
     level: '13',


### PR DESCRIPTION
There are some more but I haven't had time to compare more thoroughly. All of the images already exist it seems, locally I was able to see them.

I found one of the camos in "uncategorized" but not the other. Maybe there's a better way to organize camos by having them be an object with the category inside and have the page sort them out