### PR TITLE
Added missing Reclaimer 18 Shotgun, and its camo challenges

### DIFF
--- a/src/data/camouflages/cuteCritters.js
+++ b/src/data/camouflages/cuteCritters.js
@@ -5,6 +5,7 @@ const multiplayer = [
   'Blacklight',
   'Penny',
   'No-Fly Zone',
+  'Bugged Out',
 ]
 
 const zombies = [
@@ -14,6 +15,7 @@ const zombies = [
   'Spectral',
   'Lurker',
   'Flightless Bird',
+  'Dead Creeper',
 ]
 
 const camouflages = [...multiplayer, ...zombies].sort((a, b) => a.localeCompare(b))

--- a/src/data/camouflages/fun.js
+++ b/src/data/camouflages/fun.js
@@ -6,6 +6,7 @@ const multiplayer = [
   'Sunny Side',
   'Evil Spawn',
   'The Last Post',
+  'Donut Worry',
 ]
 
 const zombies = [
@@ -14,6 +15,7 @@ const zombies = [
   'Anomaly',
   'Necromancy',
   'Forum Chaser',
+  'Tangy Donut',
 ]
 
 const camouflages = [...multiplayer, ...zombies].sort((a, b) => a.localeCompare(b))

--- a/src/data/camouflages/geometric.js
+++ b/src/data/camouflages/geometric.js
@@ -1,6 +1,6 @@
-const multiplayer = ['Get Stony', 'Shuffle']
+const multiplayer = ['Get Stony', 'Shuffle', 'Azure Refract']
 
-const zombies = ['Puncture', 'Jagged Edges']
+const zombies = ['Puncture', 'Jagged Edges', 'Crystalized']
 
 const camouflages = [...multiplayer, ...zombies].sort((a, b) => a.localeCompare(b))
 

--- a/src/data/defaults/progress/shotguns.js
+++ b/src/data/defaults/progress/shotguns.js
@@ -1,4 +1,20 @@
 export default {
+  'Reclaimer 18': {
+    multiplayer: {
+      'Bugged Out': false,
+      'He\'s Looking At You': false,
+      'Azure Refract': false,
+      'Donut Worry': false,
+    },
+
+    zombies: {
+      'Dead Creeper': false,
+      'Evil-Eye-Ris': false,
+      'Crystalized': false,
+      'Tangy Donut': false,
+    },
+  },
+
   'Lockwood 680': {
     multiplayer: {
       'Blue Sands': false,

--- a/src/data/requirements/camouflages/cuteCritters.js
+++ b/src/data/requirements/camouflages/cuteCritters.js
@@ -106,4 +106,22 @@ export default {
       type: 'kills_in_medium_or_high_threat_zone',
     },
   },
+
+  'Bugged Out': {
+    weapon: 'Reclaimer 18',
+    level: '2',
+    challenge: {
+      amount: 50,
+      type: 'kills',
+    },
+  },
+
+  'Dead Creeper': {
+    weapon: 'Reclaimer 18',
+    level: '2',
+    challenge: {
+      amount: 250,
+      type: 'kills',
+    },
+  },
 }

--- a/src/data/requirements/camouflages/fun.js
+++ b/src/data/requirements/camouflages/fun.js
@@ -106,4 +106,23 @@ export default {
       type: 'kills',
     },
   },
+
+  'Donut Worry': {
+    weapon: 'Reclaimer 18',
+    level: '15',
+    challenge: {
+      amount: 10,
+      type: 'double_kills',
+    },
+  },
+
+  'Tangy Donut': {
+    weapon: 'Torque 35',
+    level: '15',
+    challenge: {
+      amount: 20,
+      times: 10,
+      type: 'consecutive_kills_without_taking_damage',
+    },
+  },
 }

--- a/src/data/requirements/camouflages/geometric.js
+++ b/src/data/requirements/camouflages/geometric.js
@@ -17,6 +17,15 @@ export default {
     },
   },
 
+  'Azure Refract': {
+    weapon: 'Reclaimer 18',
+    level: '10',
+    challenge: {
+      amount: 10,
+      type: 'kills_while_ads',
+    },
+  },
+
   'Puncture': {
     weapon: 'FR 5.56',
     level: '2',
@@ -32,6 +41,15 @@ export default {
     challenge: {
       amount: 250,
       type: 'kills_at_rare_or_higher_rarity',
+    },
+  },
+
+  'Crystalized': {
+    weapon: 'Reclaimer 18',
+    level: '10',
+    challenge: {
+      amount: 250,
+      type: 'kills_with_electric_damage',
     },
   },
 }

--- a/src/data/requirements/weapons/shotguns.js
+++ b/src/data/requirements/weapons/shotguns.js
@@ -1,6 +1,53 @@
 import requirements from '@/data/requirements/camouflages'
 
 export default {
+  'Reclaimer 18': {
+    // Multiplayer
+    'Bugged Out': requirements['Bugged Out'],
+    'He\'s Looking At You': requirements['He\'s Looking At You'],
+    'Azure Refract': requirements['Azure Refract'],
+    'Donut Worry': requirements['Donut Worry'],
+
+    // Zombies
+    'Dead Creeper': requirements['Dead Creeper'],
+    'Evil-Eye-Ris': requirements['Evil-Eye-Ris'],
+    'Crystalized': requirements['Crystalized'],
+    'Tangy Donut': requirements['Tangy Donut'],
+
+    'Gilded': {
+      amount: 2,
+      times: 10,
+      type: 'kills_shortly_after_sprinting_one_life',
+    },
+
+    'Forged': {
+      amount: 2,
+      seconds: 10,
+      times: 15,
+      type: 'time_limit_kills',
+    },
+
+    'Priceless': {
+      amount: 10,
+      type: 'hipfire_kills_while_strafing',
+    },
+
+    'Golden Enigma': {
+      amount: 100,
+      type: 'kills_and_successfully_extract_in_a_single_deployment',
+    },
+
+    'Zircon Scale': {
+      amount: 300,
+      type: 'pack_a_punched_kills',
+    },
+
+    'Serpentinite': {
+      amount: 10,
+      type: 'special_or_elite_zombie_kills',
+    },
+  },
+
   'Lockwood 680': {
     // Multiplayer
     'Blue Sands': requirements['Blue Sands'],

--- a/src/data/weapons/shotguns.js
+++ b/src/data/weapons/shotguns.js
@@ -3,7 +3,7 @@ import defaultCompletionistProgress from '@/data/defaults/progress/completionist
 import defaultMasteryProgress from '@/data/defaults/progress/mastery'
 
 // The order of the weapons in this array is the order they will appear in the app
-const weapons = [{ name: 'Lockwood 680' }, { name: 'Haymaker' }, { name: 'Riveter' }]
+const weapons = [{ name: 'Reclaimer 18' }, { name: 'Lockwood 680' }, { name: 'Haymaker' }, { name: 'Riveter' }]
 
 export default weapons.map((weapon) => ({
   category: 'Shotguns',


### PR DESCRIPTION
Ripping through the camo grind, I noticed the Reclaimer was missing, so I added it! It seemed like the images were already in place, I just had to add the shotgun itself to the category, and fill in the camo challenges.

I hope I did this right, it was mostly copy/pasting already existing data and adjusting all the values accordingly, so I had done it through the github editor. Let me know if I fucked up by doing so.